### PR TITLE
Adding metadata information about python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,12 @@ setup(
         'jsonschema<3.0.0',
         'mistune',
         'six>=1.10.0'
+    ],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
     ]
 )


### PR DESCRIPTION
Flasgger was pointed out as non python 3 compatible by caniusepython3 tool, which is not true.
This errors was caused by the lack off metadata information in this package. So, adding this info to flasgger would be a little, but nice improvement :)